### PR TITLE
Refactorizacion de la creacion de los mensajes y el estado

### DIFF
--- a/lib/presentation/providers/chat/basic_chat.dart
+++ b/lib/presentation/providers/chat/basic_chat.dart
@@ -27,33 +27,37 @@ class BasicChat extends _$BasicChat {
   }
 
   void _addTextMessage({ required PartialText partialText, required User author}) {
-    final message = TextMessage(
-      id: uuid.v4(),
-      author: author,
-      text: partialText.text,
-      createdAt: DateTime.now().millisecondsSinceEpoch,
-    );
-
-    state = [ message, ...state ];
+    _createTextMessage(partialText.text, author);
 
     _geminiTextResponse(partialText.text);
   }
 
   void _geminiTextResponse(String prompt)async {
-    final isGeminiWriting = ref.read(isGeminiWritingProvider.notifier);
-    final geminiUser = ref.read(geminiUserProvider);
+    _setGeminiWritingStatus(  true);
 
-    isGeminiWriting.setIsWriting();
+    final geminiUser = ref.read(geminiUserProvider);
 
     final textResp = await geminiImpl.getResponse(prompt);
 
-    isGeminiWriting.setIsNotWriting();
+    _setGeminiWritingStatus(false);
+    
+    _createTextMessage(textResp, geminiUser);
+  }
+
+  void _createTextMessage(String text, User author){
     final message = TextMessage(
       id: uuid.v4(),
-      author: geminiUser,
-      text: textResp,
+      author: author,
+      text: text,
       createdAt: DateTime.now().millisecondsSinceEpoch,
     );
     state = [ message, ...state ];
+  }
+
+  // Helper Methods
+  void _setGeminiWritingStatus(bool isWriting) {
+    final isGeminiWriting = ref.read(isGeminiWritingProvider.notifier);
+    isWriting ? isGeminiWriting.setIsWriting() : isGeminiWriting.setIsNotWriting();
+
   }
 }


### PR DESCRIPTION
This pull request refactors the message creation and Gemini writing status logic in the `BasicChat` provider to improve code reuse and clarity. The main changes are the extraction of helper methods for message creation and writing status updates, and the simplification of the flow for handling Gemini responses.

**Refactoring for code reuse and clarity:**

* Extracted the message creation logic into a new private helper method `_createTextMessage`, reducing duplication and centralizing the construction of `TextMessage` objects.
* Added a private helper method `_setGeminiWritingStatus` to encapsulate the logic for updating Gemini's writing status, making the code easier to maintain and read.

**Simplification of Gemini response handling:**

* Updated `_geminiTextResponse` to use the new helper methods for setting writing status and creating response messages, streamlining the flow and improving readability.
* Modified `_addTextMessage` to delegate message creation to `_createTextMessage`, further reducing code duplication.