### PR TITLE
Usando stream para recibir la info del chat

### DIFF
--- a/lib/config/gemini/gemini_impl.dart
+++ b/lib/config/gemini/gemini_impl.dart
@@ -31,4 +31,30 @@ class GeminiImpl {
       return 'Error en la peticion a Gemini';
     }
   }
+
+  Stream<String> getResponseStream(String prompt) async* {
+   try{
+      // TODO: Tener presente que vamos a enviar imagenes tambien
+      //! Multipart 
+      final body = {'prompt': prompt};
+      final response = await _http.post('/basic-prompt-stream', 
+        data: jsonEncode(body), 
+        options: Options(
+          responseType: ResponseType.stream,
+        )
+      );
+
+      final stream = response.data.stream as Stream<List<int>>;
+      String buffer = '';
+
+      await for (final chunk in stream) {
+        final chunkString = utf8.decode(chunk, allowMalformed: true);
+        buffer += chunkString;
+        yield buffer;
+      }
+
+    }catch(e){
+      yield 'Error en la peticion a Gemini';
+    }
+  }
 }

--- a/lib/presentation/providers/chat/basic_chat.dart
+++ b/lib/presentation/providers/chat/basic_chat.dart
@@ -29,7 +29,8 @@ class BasicChat extends _$BasicChat {
   void _addTextMessage({ required PartialText partialText, required User author}) {
     _createTextMessage(partialText.text, author);
 
-    _geminiTextResponse(partialText.text);
+    //_geminiTextResponse(partialText.text);
+    _geminiTextResponseStream(partialText.text);
   }
 
   void _geminiTextResponse(String prompt)async {
@@ -42,6 +43,24 @@ class BasicChat extends _$BasicChat {
     _setGeminiWritingStatus(false);
     
     _createTextMessage(textResp, geminiUser);
+  }
+  void _geminiTextResponseStream(String prompt)async {
+
+    _createTextMessage('Gemini esta pensando...', ref.read(geminiUserProvider));
+
+    geminiImpl.getResponseStream(prompt).listen((respChunk) {
+      if(respChunk.isEmpty) return;
+
+      final updatedMessages = [ ...state ];
+      final updateMessage = ( updatedMessages.first as TextMessage).copyWith(
+        text: respChunk,
+      );
+
+      updatedMessages[0] = updateMessage;
+
+      state = updatedMessages;
+    });
+
   }
 
   void _createTextMessage(String text, User author){

--- a/lib/presentation/providers/chat/basic_chat.g.dart
+++ b/lib/presentation/providers/chat/basic_chat.g.dart
@@ -6,7 +6,7 @@ part of 'basic_chat.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$basicChatHash() => r'1535e7b8c859236d5bcf8246e3767ed27c162a76';
+String _$basicChatHash() => r'eba52bc135aebddbc2f3160d6ea6fa760f769ae1';
 
 /// See also [BasicChat].
 @ProviderFor(BasicChat)


### PR DESCRIPTION
Se introduce la compatibilidad con streaming para las respuestas de texto de Gemini en el proveedor de chat, lo que permite actualizaciones en tiempo real a medida que Gemini genera su respuesta. Los principales cambios incluyen la adición de un nuevo método de streaming a `GeminiImpl`, la actualización del proveedor de chat para que utilice este flujo y la gestión de actualizaciones incrementales de mensajes en la interfaz de usuario.

**Integración de streaming con Gemini:**

* Se añadió el método `getResponseStream` a `GeminiImpl` en `lib/config/gemini/gemini_impl.dart`, lo que permite la transmisión de las respuestas de Gemini fragmento a fragmento. Este método genera respuestas parciales a medida que llegan, lo que mejora la experiencia del usuario con retroalimentación en tiempo real.

**Actualizaciones del proveedor de chat:**

* Se modificó `_addTextMessage` en `BasicChat` (`lib/presentation/providers/chat/basic_chat.dart`) para utilizar el nuevo método de respuesta de streaming en lugar del enfoque anterior de respuesta única. * Se añadió `_geminiTextResponseStream` a `BasicChat`, que escucha el flujo de respuesta de Gemini y actualiza el primer mensaje del chat con cada nuevo fragmento recibido, lo que permite a los usuarios ver la respuesta de Gemini a medida que se genera.

**Generación de código:**

* Se actualizó el hash de Riverpod en `lib/presentation/providers/chat/basic_chat.g.dart` para reflejar los cambios en la lógica del proveedor.